### PR TITLE
Resolve out-of-bounds issues with packet writing

### DIFF
--- a/videostreamer.go
+++ b/videostreamer.go
@@ -388,6 +388,11 @@ func (h HTTPHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 // Read from a pipe where streaming media shows up. We read a chunk and write it
 // immediately to the client, and repeat forever (until either the client goes
 // away, or an error of some kind occurs).
+//
+// TODO: according to gdb / valgrind, this function throws thousands of
+//       read/write errors in network-related code, and causing memory
+//       leaks as well
+//
 func (h HTTPHandler) streamRequest(rw http.ResponseWriter, r *http.Request) {
 	// The encoder writes to the out pipe (using the packetWriter goroutine). We
 	// read from the in pipe.


### PR DESCRIPTION
I noticed a number of out-of-bounds errors present when running your videostreamer alongside valgrind / gdb. As a result, I have added a number of safety checks and functionality is kept the same while fewer errors occur. Several TODOs were added as well since I think more testing might be required to guarantee that this code is safe in threaded environments.

Feel free to test it on your side to ensure this works and let me know what you think.