### PR TITLE
videostreamer.c: dont call avformat_free_context

### DIFF
--- a/videostreamer.c
+++ b/videostreamer.c
@@ -114,8 +114,7 @@ vs_destroy_input(struct VSInput * const input)
 	}
 
 	if (input->format_ctx) {
-		avformat_close_input(&input->format_ctx);
-		avformat_free_context(input->format_ctx);
+		avformat_close_input(&input->format_ctx);		
 	}
 
 	free(input);


### PR DESCRIPTION
avformat_close_input  frees context and all its contents and set it to NULL
https://www.ffmpeg.org/doxygen/3.3/group__lavf__decoding.html#gae804b99aec044690162b8b9b110236a4